### PR TITLE
Add loading indicator and change selenium tests to headless mode.

### DIFF
--- a/app/static/css/specification.css
+++ b/app/static/css/specification.css
@@ -149,7 +149,6 @@
 
 .plot .controls {
   display: block;
-  height: 40px;
 }
 
 .plot .controls a.close-plot {

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -4,6 +4,26 @@ body {
 	font-family: arial;
 }
 
+@keyframes spinner-border {
+  to { transform: rotate(360deg); }
+}
+
+.loading-spinner {
+    display: inline-block;
+    position: absolute;
+    right: 20px;
+    top: 25px;
+    z-index: 2000;
+    width: 2rem;
+    height: 2rem;
+    vertical-align: text-bottom;
+    border: .25em solid white;
+    border-right-color: transparent;
+    border-radius: 50%;
+    -webkit-animation: spinner-border .75s linear infinite;
+    animation: spinner-border .75s linear infinite;
+}
+
 .navbar-header {
 	height: 70px;
 }

--- a/app/static/js/by_specification_vue.js
+++ b/app/static/js/by_specification_vue.js
@@ -4,6 +4,19 @@ var selected_calls = [];
 // global plot data, used for when plot are updated with new data
 var plot_visible = false;
 var plot_data = null;
+var Store = {
+    status : {
+        loading : false
+    }
+};
+
+var start_loading = function() {
+    Store.status.loading = true;
+}
+
+var stop_loading = function() {
+    Store.status.loading = false;
+}
 
 var decodeHTML = function (html) {
   var txt = document.createElement('textarea');
@@ -51,8 +64,26 @@ var generate_plot = function(root_obj) {
 
       // emit plot data ready event so the plot will be drawn
       that.$root.$emit("plot-data-ready", myData);
+      start_loading();
     });
 };
+
+
+Vue.component("loading-spinner", {
+  template : `
+  <div class="loading-spinner" role="status" v-if="in_progress"></div>
+  `,
+  data : function() {
+    return {
+      store : Store
+    }
+  },
+  computed : {
+    in_progress : function() {
+      return this.store.status.loading;
+    }
+  }
+});
 
 
 Vue.component("machine-function-property", {
@@ -191,7 +222,8 @@ Vue.component("subtreelevel", {
   },
   methods : {
     selectFunction: function(id, code){
-      console.log(id)
+      console.log(id);
+      start_loading();
       this.$root.$emit('function-select', {selected_function_id: id, specification_code: code})
     }
   }
@@ -222,6 +254,7 @@ Vue.component("function-calls", {
   },
   methods: {
     select_all_calls: function(){
+      start_loading();
       var is_checked = $("#select-all").prop("checked");
       $("input:checkbox").prop("checked", is_checked);
       if (is_checked) {
@@ -232,6 +265,7 @@ Vue.component("function-calls", {
       else {
         this.checkedCalls = [];
       }
+      stop_loading();
     }
   },
   mounted(){
@@ -257,11 +291,13 @@ Vue.component("function-calls", {
         obj.buttons = buttons_list;
 
         obj.$root.$emit('calls-loaded', dict);
+        stop_loading();
       })
     })
   },
   watch: {
     checkedCalls: function(value){
+      start_loading();
       console.log(value)
       var function_call_ids = [];
       var that = this;
@@ -276,12 +312,14 @@ Vue.component("function-calls", {
               console.log(JSON.stringify(tree))
               that.$root.$emit('calls-selected',tree);
               selected_calls = function_call_ids;
+              stop_loading();
             });
         } else {
             // add data to plot without displaying code interface
             plot_data.calls = function_call_ids;
             // trigger plotting
             generate_plot(this);
+            stop_loading();
         }
       }
     }
@@ -364,6 +402,7 @@ Vue.component("code-view", {
   mounted(){
     var obj2 = this;
     this.$root.$on('calls-loaded', function(dict){
+      start_loading();
       obj2.message = "";
       obj2.specification_code = dict["specification_code"];
       axios.get('/get_source_code/'+dict["selected_function_id"]).then(function(response){
@@ -418,6 +457,7 @@ Vue.component("code-view", {
             //$("#span-bindings-line-"+no).append(" "+binding["id"]);
           } //end j-loop
         } //end i-loop
+        stop_loading();
       })
     })
     this.$root.$on('calls-selected', function(tree){
@@ -741,18 +781,18 @@ Vue.component("dropdown", {
   },
   methods: {
     selectOption: function(data){
+      start_loading();
       if (data["action"] == "simple-plot"){
         // set the plot data globally
         plot_data = data;
         // plot the data we just set
         generate_plot(this);
-        // display the plot
-        $("#plot-wrapper").toggleClass("show");
       }
       // TODO
       else if (data["action"] == "simple-path") {}
       else if (data["action"] == "mixed-select") {}
       else if (data["action"] == "between-select") {}
+      stop_loading();
     }
   }
 })
@@ -774,6 +814,11 @@ Vue.component("plot", {
       plot_visible = false;
     })
     this.$root.$on("plot-data-ready", function(data_array){
+      // display the plot
+      $("#plot-wrapper").toggleClass("show");
+      // set height of plot wrapper
+      $("#plot-wrapper").height($("#code-listing").outerHeight());
+      $("#plot-svg").width($("#code-listing").outerWidth()-10);
       //var data_array = data["array"];
       nv.addGraph(function() {
         var chart = nv.models.multiBarChart()
@@ -797,37 +842,12 @@ Vue.component("plot", {
 
         nv.utils.windowResize(chart.update);
 
-        // set height of plot wrapper
-        $("#plot-wrapper").height($("#code-listing").outerHeight());
-
         // set initial size
         chart.update();
 
+        stop_loading();
+
         return chart;
-        /* //for scatter plot
-        nv.addGraph(function() {
-          var chart = nv.models.scatterChart()
-            .color([d3.rgb("green")])
-
-          chart.xAxis.tickFormat(function(d) { return d3.time.format('%H:%M:%S')(new Date(d)); });
-          chart.yAxis.tickFormat(d3.format('.02f'));
-
-          var myData = [{key: 'group 1', values: []}];
-          for (var i=0; i<data["x"].length; i++){
-            console.log(new Date(Date.parse(data["x"][i])))
-            myData[0].values.push({x: new Date(Date.parse(data["x"][i])),
-                                   y: data["y"][i],
-                                   size: 7,
-                                   shape: "circle"});
-          }
-          d3.select('#plot-svg').datum(myData).call(chart);
-
-          nv.utils.windowResize(chart.update);
-
-          return chart;
-        }); */
-
-
       });
     })
   },

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -4,10 +4,8 @@
 
 <link href="{{ url_for('static', filename='css/bootstrap.min.css') }}" rel="stylesheet" />
 <link href="{{ url_for('static', filename='css/style.css') }}" rel="stylesheet" />
-<script type="text/javascript" src="{{ url_for('static', filename='js/jquery-3.3.1.min.js') }}"></script>
-
-{% block css_import %}
-{% endblock %}
+<link href="{{ url_for('static', filename='css/specification.css') }}" rel="stylesheet" />
+<link rel="stylesheet" type="text/css" href="https://raw.github.com/novus/nvd3/master/src/nv.d3.css"/>
 
 <title>Verdict Data</title>
 </head>
@@ -21,7 +19,9 @@
       <a class="navbar-brand" href="/">
         <img alt="Brand" src="{{url_for('static', filename='logos/vypr-logo.jpeg') }}">
       </a>
-        <div class="tagline">Analysis Environment</div>
+        <div class="tagline">
+            Analysis Environment
+        </div>
     </div>
     </div><!-- /.navbar-collapse -->
   </div><!-- /.container-fluid -->
@@ -30,8 +30,12 @@
 {% block body %}
 {% endblock %}
 
-{% block js_import %}
-{% endblock %}
+<script type="text/javascript" src="{{ url_for('static', filename='js/jquery-3.3.1.min.js') }}"></script>
+<script src="https://cdn.jsdelivr.net/npm/vue/dist/vue.js"></script>
+<script src="https://unpkg.com/axios/dist/axios.min.js"></script>
+<script src="https://d3js.org/d3.v3.min.js"></script>
+<script src="https://cdn.rawgit.com/novus/nvd3/v1.8.1/build/nv.d3.js"></script>
+<script type="text/javascript" src="{{ url_for('static', filename='js/by_specification_vue.js') }}"></script>
 
 </body>
 

--- a/app/templates/by_specification_vue.html
+++ b/app/templates/by_specification_vue.html
@@ -1,21 +1,10 @@
 {% extends "base.html" %}
 
-{% block js_import %}
-<script src="https://cdn.jsdelivr.net/npm/vue/dist/vue.js"></script>
-<script src="https://unpkg.com/axios/dist/axios.min.js"></script>
-<script src="https://d3js.org/d3.v3.min.js"></script>
-<script src="https://cdn.rawgit.com/novus/nvd3/v1.8.1/build/nv.d3.js"></script>
-<script type="text/javascript" src="{{ url_for('static', filename='js/by_specification_vue.js') }}"></script>
-{% endblock %}
-
-{% block css_import %}
-<link href="{{ url_for('static', filename='css/specification.css') }}" rel="stylesheet" />
-<link rel="stylesheet" type="text/css" href="https://raw.github.com/novus/nvd3/master/src/nv.d3.css"/>
-{% endblock %}
-
 {% block body %}
 
 <div id="app">
+
+    <loading-spinner></loading-spinner>
 
     <div class="container-fluid">
 

--- a/tests/run.py
+++ b/tests/run.py
@@ -4,6 +4,7 @@ from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support.expected_conditions import presence_of_element_located
 from selenium.webdriver import ActionChains
+from selenium.webdriver.firefox.options import Options
 
 import unittest
 
@@ -33,7 +34,9 @@ def check_if_exists(element, tag_name):
 class TestBaseFirefox(unittest.TestCase):
 
     def setUp(self):
-        self.driver = webdriver.Firefox()
+        options = Options()
+        options.headless = True
+        self.driver = webdriver.Firefox(options=options)
 
     def tearDown(self):
         self.driver.close()


### PR DESCRIPTION
Known problems:
- Loading indicator sometimes doesn't appear for DOM-intensive operations because Vue pushes it into the next 'tick', so it only appears briefly.
- Interaction in the browser is fine but a selenium test now fails with error
```
Traceback (most recent call last):
  File "tests/run.py", line 122, in test_choosing_function
    assert len(calls)==first_f_calls
AssertionError
```
- There are multiple event handlers in the web tool javascript for `calls-loaded`.  I'm not sure if this is okay or not.